### PR TITLE
Fix "ersion" typo in SD webui

### DIFF
--- a/SD-webui/docker-compose.yml
+++ b/SD-webui/docker-compose.yml
@@ -1,4 +1,4 @@
-ersion: '3'
+version: '3'
 services:
   sd-webui:
     image: woodrex/sd-webui-for-gfx803:latest


### PR DESCRIPTION
Typo.

Version value is obsolete, ignored and should be removed but at least it runs.